### PR TITLE
Added a failing test case for task ordering

### DIFF
--- a/src/test/scala/com/miguno/akka/testing/MockSchedulerSpec.scala
+++ b/src/test/scala/com/miguno/akka/testing/MockSchedulerSpec.scala
@@ -104,10 +104,12 @@ class MockSchedulerSpec extends FunSpec with Matchers with GivenWhenThen {
       time.scheduler.scheduleOnce(delay)(counter.compareAndSet(0, 1))
       And("I then schedule a one-time task B to run at the same time as A")
       time.scheduler.scheduleOnce(delay)(counter.compareAndSet(1, 42))
+      And("I then schedule a one-time task C to run at the same time as B")
+      time.scheduler.scheduleOnce(delay)(counter.compareAndSet(42, 80))
 
-      Then("A should run before B")
+      Then("A should run before B and B should run before C")
       time.advance(delay)
-      counter.get should be(42)
+      counter.get should be(80)
     }
 
     it("should, for tasks that are scheduled for the same time, run one-time tasks before subsequent runs of recurring tasks") {


### PR DESCRIPTION
Tasks do not always get executed in order for tasks of an equal priority. A priority queue doesn't  guarantee insertion order is retained. 

Possible fixes could be adding an extra sort field such an an incrementing integer value so that you sort by the `delay` and then the integer, or using a SortedMap[FiniteDuration, Seq[Task]], the key being a particular Task `delay` and the value being the ordered Tasks at that `delay`.
