### PR TITLE
Bump dependency versions, scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ after_success: "./sbt coveralls"
 language: scala
 
 scala:
-   - 2.10.5
-   - 2.11.7
+   - 2.11.8
+   - 2.12.0
 
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - oraclejdk8
 
 # Workaround for Travis CI issue 5227, which results in a buffer overflow
 # caused by Java when running the build on OpenJDK.

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ resolvers ++= Seq(
 // Variables
 // -------------------------------------------------------------------------------------------------------------------
 
-val akkaVersion = "2.3.14"
-val javaVersion = "1.7"
-val mainScalaVersion = "2.10.5"
+val akkaVersion = "2.4.14"
+val javaVersion = "1.8"
+val mainScalaVersion = "2.11.8"
 
 
 // -------------------------------------------------------------------------------------------------------------------
@@ -26,7 +26,7 @@ val mainScalaVersion = "2.10.5"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.mockito" % "mockito-all" % "1.10.19" % "test"
 )
 
@@ -35,7 +35,7 @@ libraryDependencies ++= Seq(
 // Compiler settings
 // ---------------------------------------------------------------------------------------------------------------------
 
-crossScalaVersions := Seq(mainScalaVersion, "2.11.7")
+crossScalaVersions := Seq(mainScalaVersion, "2.12.0")
 
 scalaVersion := mainScalaVersion
 
@@ -123,12 +123,6 @@ testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/te
 //        testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oWUDT", "-eWUDT")
 //
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-o")
-
-// Workaround for highlighting, required for Scala versions < 2.11.2.
-// See https://github.com/scoverage/sbt-scoverage#highlighting
-ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
-  if (scalaBinaryVersion.value == "2.10") false else false
-}
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Misc settings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 // https://github.com/scoverage/scalac-scoverage-plugin
 // https://github.com/scoverage/sbt-scoverage
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 // https://github.com/scoverage/sbt-coveralls
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")


### PR DESCRIPTION
- Update Akka 2.4.14, which leads to dropping support of scala 2.10.x.
- scala 2.11.8 default scala version
- support scala 2.12.0