### PR TITLE
Fixed #8 - Cancelled recurring task keeps executing

### DIFF
--- a/src/main/scala/com/miguno/akka/testing/MockCancellable.scala
+++ b/src/main/scala/com/miguno/akka/testing/MockCancellable.scala
@@ -2,7 +2,7 @@ package com.miguno.akka.testing
 
 import akka.actor.Cancellable
 
-private[testing] case class MockCancellable(scheduler: MockScheduler, task: Task) extends Cancellable {
+private[testing] case class MockCancellable(scheduler: MockScheduler, taskId: Long) extends Cancellable {
 
   private[this] var canceled: Boolean = false
 
@@ -21,7 +21,7 @@ private[testing] case class MockCancellable(scheduler: MockScheduler, task: Task
         case true => false
         case false => {
           canceled = true
-          scheduler.cancelTask(task)
+          scheduler.cancelTask(taskId)
           true
         }
       }

--- a/src/main/scala/com/miguno/akka/testing/MockScheduler.scala
+++ b/src/main/scala/com/miguno/akka/testing/MockScheduler.scala
@@ -55,12 +55,12 @@ class MockScheduler(time: VirtualTime) extends Scheduler {
       val startTime = time.elapsed + delay
       val task = new Task(startTime, id, runnable, interval)
       tasks += task
-      MockCancellable(this, task)
+      MockCancellable(this, task.id)
     }
 
-  private[testing] def cancelTask(task: Task): Unit = {
+  private[testing] def cancelTask(taskId: Long): Unit = {
     time.lock synchronized {
-      tasks = tasks.filterNot { x => x == task }
+      tasks = tasks.filterNot { x => x.id == taskId}
     }
   }
 

--- a/src/test/scala/com/miguno/akka/testing/MockCancellableSpec.scala
+++ b/src/test/scala/com/miguno/akka/testing/MockCancellableSpec.scala
@@ -5,11 +5,13 @@ import org.scalatest.{FunSpec, GivenWhenThen, Matchers}
 
 class MockCancellableSpec extends FunSpec with Matchers with GivenWhenThen with MockitoSugar {
 
+  val mockId = 0L
+
   describe("MockCancellable") {
 
     it("should return true when cancelled the first time") {
       Given("an instance")
-      val cancellable = MockCancellable(mock[MockScheduler], mock[Task])
+      val cancellable = MockCancellable(mock[MockScheduler], mockId)
 
       When("I cancel it the first time")
       val result = cancellable.cancel()
@@ -20,7 +22,7 @@ class MockCancellableSpec extends FunSpec with Matchers with GivenWhenThen with 
 
     it("should return false when cancelled the second time") {
       Given("an instance")
-      val cancellable = MockCancellable(mock[MockScheduler], mock[Task])
+      val cancellable = MockCancellable(mock[MockScheduler], mockId)
 
       When("I cancel it the second time")
       cancellable.cancel()
@@ -32,7 +34,7 @@ class MockCancellableSpec extends FunSpec with Matchers with GivenWhenThen with 
 
     it("isCancelled should return false when cancel was not called yet") {
       Given("an instance")
-      val cancellable = MockCancellable(mock[MockScheduler], mock[Task])
+      val cancellable = MockCancellable(mock[MockScheduler], mockId)
 
       When("I ask whether it has been cancelled")
       Then("it returns false")
@@ -41,7 +43,7 @@ class MockCancellableSpec extends FunSpec with Matchers with GivenWhenThen with 
 
     it("isCancelled should return true when cancel was called already") {
       Given("an instance")
-      val cancellable = MockCancellable(mock[MockScheduler], mock[Task])
+      val cancellable = MockCancellable(mock[MockScheduler], mockId)
 
       And("the instance was cancelled")
       cancellable.cancel()

--- a/src/test/scala/com/miguno/akka/testing/MockSchedulerSpec.scala
+++ b/src/test/scala/com/miguno/akka/testing/MockSchedulerSpec.scala
@@ -149,6 +149,29 @@ class MockSchedulerSpec extends FunSpec with Matchers with GivenWhenThen {
       Then("the task should not run")
       counter.get should be(0)
     }
+
+    it("should not run a recurring cancelled task") {
+      Given("a time with a scheduler")
+      val time = new VirtualTime
+      And("and an execution context")
+      import scala.concurrent.ExecutionContext.Implicits.global
+
+      When("I schedule a recurring task")
+      val delay = 5.millis
+      val counter = new AtomicInteger(0)
+      val scheduledIncrement = time.scheduler.schedule(delay, delay)(counter.getAndIncrement)
+
+      And("I advance the time so that task is executed once")
+      time.advance(delay)
+      counter.get should be(1)
+
+      And("I cancel the task and advance the time further")
+      scheduledIncrement.cancel()
+      time.advance(delay)
+
+      Then("the task should not run any more")
+      counter.get should be(1)
+    }
   }
 
 }


### PR DESCRIPTION
Proposed fix for #8 - recurring tasks not being cancelled.
I suggest to track tasks by their ids only - then cancellation removes rescheduled recurring tasks as well.